### PR TITLE
Update python_version for 3.13

### DIFF
--- a/qualys_ssllabs.json
+++ b/qualys_ssllabs.json
@@ -6,7 +6,7 @@
     "publisher": "Splunk",
     "main_module": "qualys_ssllabs_connector.py",
     "app_version": "2.0.6",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "utctime_updated": "2025-04-14T21:23:53.083707Z",
     "package_name": "phantom_qualys_ssllabs",
     "product_vendor": "Qualys",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13)