### PR TITLE
Fix python_version format

### DIFF
--- a/qualys_ssllabs.json
+++ b/qualys_ssllabs.json
@@ -6,10 +6,7 @@
     "publisher": "Splunk",
     "main_module": "qualys_ssllabs_connector.py",
     "app_version": "2.0.7",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "utctime_updated": "2025-07-30T17:52:22.969210Z",
     "package_name": "phantom_qualys_ssllabs",
     "product_vendor": "Qualys",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)